### PR TITLE
Fixed ValueError when setting penalty to number instead of float

### DIFF
--- a/scripts/promptgen.py
+++ b/scripts/promptgen.py
@@ -62,7 +62,7 @@ def generate_batch(input_ids, min_length, max_length, num_beams, temperature, re
         input_ids,
         do_sample=True,
         temperature=max(float(temperature), 1e-6),
-        repetition_penalty=repetition_penalty,
+        repetition_penalty=float(repetition_penalty),
         length_penalty=length_penalty,
         top_p=top_p,
         top_k=top_k,


### PR DESCRIPTION
Fixed ValueError by enforcing repetition_penalty to stay as float in generate_batch function.

Example of error:
ValueError: `penalty` has to be a strictly positive float, but is 2

Steps to reproduce mentioned error:
1. Go to promptgen
2. Enter number in `repetition penalty` field without floating point
3. ![image](https://user-images.githubusercontent.com/58131574/227720454-c0ce6809-94ff-4375-8c37-708c4258473c.png)